### PR TITLE
Forward-merge: release/1.0.2 into main with conflicts resolved (completes #89)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,10 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev, 'release/**']
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev, 'release/**']
+  workflow_dispatch:
 
 name: R-CMD-check
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
   release:
     types: [published]
   workflow_dispatch:
@@ -42,7 +42,8 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
+        # deploy only from main; dev builds are check-only
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,0 @@
-Version: 1.0.0
-Date: 2024-11-01 14:16:03 UTC
-SHA: 4875bfcd7d57cabf92163f1b47d963cb7d6bb720

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: washr
 Title: Publication Toolkit for Water, Sanitation and Hygiene (WASH) Data
-Version: 1.0.2
+Version: 1.0.2.9000
 Date: 2026-07-23
 Authors@R: c(
     person("Mian", "Zhong", , "mzhong@ethz.ch", role = "aut",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: washr
 Title: Publication Toolkit for Water, Sanitation and Hygiene (WASH) Data
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: c(
     person("Mian", "Zhong", , "mzhong@ethz.ch", role = "aut",
            comment = c(ORCID = "0009-0009-4546-7214")),
     person("Margaux", "Götschmann", , "margauxg@ethz.ch", role = "aut",
            comment = c(ORCID = "0009-0002-2567-3343")),
-    person("Colin", "Walder", , "cwalder@ethz.ch", role = c("aut", "cre"),
+    person("Colin", "Walder", , "cwalder@ethz.ch", role = "aut",
            comment = c(ORCID = "0009-0006-0969-1954")),
-    person("Lars", "Schöbitz", , "lschoebitz@ethz.ch", role = "aut",
+    person("Lars", "Schöbitz", , "lschoebitz@ethz.ch", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2196-5015")),
     person("Global Health Engineering, ETH Zurich", role = "cph")
   )
@@ -16,7 +16,6 @@ Description: A toolkit to set up an R data package in a consistent structure. Au
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
 Imports:
     desc (>= 1.4.3),
     devtools (>= 2.4.5),
@@ -27,7 +26,7 @@ Imports:
     utils (>= 4.3.3)
 Language: en-GB
 Config/Needs/website: rmarkdown
-Date: 2024-11-01
+Date: 2026-07-23
 URL: https://openwashdata.github.io/washr/
 BugReports: https://github.com/openwashdata/washr/issues
 Suggests: 
@@ -37,3 +36,4 @@ Suggests:
     withr (>= 3.0.0)
 Config/testthat/edition: 3
 VignetteBuilder: knitr
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# washr (development version)
+
 # washr 1.0.2
 
 Patch release: bug fixes only, no new API. New maintainer: Lars Schöbitz.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,26 @@
+# washr 1.0.2
+
+Patch release: bug fixes only, no new API. New maintainer: Lars Schöbitz.
+
+- `update_citation()` no longer requires a `doi` argument; calling it without
+  one generates the citation files without a DOI, for use before a release
+  exists (#57).
+- `update_citation(doi = NULL)` no longer injects a broken empty DOI badge
+  into README.Rmd. Re-running with a DOI replaces an existing badge instead
+  of duplicating it, heals a broken empty badge left by earlier versions,
+  and a missing `<!-- badges: end -->` marker now gives a clear error (#58).
+- `update_description()` preserves existing `URL` and `Config/Needs/website`
+  entries and merges them with the openwashdata defaults instead of
+  replacing them (#59, #63).
+- `update_description()` no longer overwrites an existing license; CC BY 4.0
+  is only set when the package has no license yet (#63).
+- `update_description()` honors its `file` argument when checking for the
+  DESCRIPTION file (#63).
+- `update_citation()` cleans up the `*.bk1` backup files that cffr leaves
+  behind when overwriting `CITATION.cff` and `inst/CITATION` (#60).
+- `setup_readme()` no longer deletes an existing README.Rmd; it stops with
+  an error unless the new `force = TRUE` argument is passed (#64).
+
 # washr 1.0.1
 
 - Implementing reviewer's comments, resubmission to CRAN

--- a/R/setup_dictionary.R
+++ b/R/setup_dictionary.R
@@ -12,18 +12,10 @@
 #' @returns NULL. Error if raw data is not found or not in a package directory.
 #'
 #' @examples
-#' \dontshow{
-#' temppkg <- tempdir()
-#' devtools::create(temppkg, open=FALSE)
-#' .old_wd <- setwd(temppkg)
-#' }
 #' \dontrun{
 #' setup_rawdata()
 #' # Go to data_processing.R, clean the raw data and export tidy data
 #' setup_dictionary()
-#' }
-#' \dontshow{
-#' setwd(.old_wd)
 #' }
 #'
 setup_dictionary <- function() {
@@ -58,14 +50,8 @@ setup_dictionary <- function() {
 #' @export
 #'
 #' @examples
-#' \dontshow{
-#' .old_wd <- setwd(tempdir())
-#' }
 #' \dontrun{
-#' update_dictionary(dict_path = "data-raw/my-dictionary.csv", data = "data/")
-#' }
-#' \dontshow{
-#' setwd(.old_wd)
+#' fill_dictionary(dict_path = "data-raw/dictionary.csv", data_dir = "data/")
 #' }
 #'
 fill_dictionary <- function(dict_path, data_dir){

--- a/R/setup_readme.R
+++ b/R/setup_readme.R
@@ -5,6 +5,9 @@
 #' retrieved from the `data/` directory. It helps in creating consistent and informative README documentation
 #' for your data packages.
 #'
+#' @param force Logical. If FALSE (the default), the function stops when a
+#' README.Rmd already exists. Set to TRUE to overwrite the existing file.
+#'
 #' @returns NULL. This function creates a README.Rmd under the package directory.
 #'
 #' @export
@@ -16,9 +19,16 @@
 #' # Complete and save the dictionary CSV file with variable descriptions
 #' setup_readme()
 #' }
-setup_readme <- function(){
+setup_readme <- function(force = FALSE){
   # Get metadata
   readmermd_path <- file.path("README.Rmd")
+  if (file.exists(readmermd_path)) {
+    if (!force) {
+      usethis::ui_stop("README.Rmd already exists.
+                        Call setup_readme(force = TRUE) to overwrite it.")
+    }
+    file.remove(readmermd_path)
+  }
   pkgname <- desc::desc_get("Package")
   dataname <- strsplit(basename(list.files("data")[1]), ".rda")[[1]]
   if (is.na(dataname)) {
@@ -35,4 +45,3 @@ setup_readme <- function(){
                         package = "washr")
   usethis::ui_todo("Finish the writing of README and run devtools::build_readme() in console.")
 }
-

--- a/R/setup_roxygen.R
+++ b/R/setup_roxygen.R
@@ -20,18 +20,10 @@
 #' @export
 #'
 #' @examples
-#' \dontshow{
-#' temppkg <- tempdir()
-#' devtools::create(temppkg, open=FALSE)
-#' .old_wd <- setwd(temppkg)
-#' }
 #' \dontrun{
 #' setup_dictionary()
 #' # Once the dictionary is created, go to data-raw/dictionary.csv and complete the column description.
 #' setup_roxygen()
-#' }
-#' \dontshow{
-#' setwd(.old_wd)
 #' }
 #'
 setup_roxygen <- function() {

--- a/R/setup_website.R
+++ b/R/setup_website.R
@@ -13,15 +13,9 @@
 #' @export
 #'
 #' @examples
-#' \dontshow{
-#' .old_wd <- setwd(tempdir())
-#' }
 #' \dontrun{
 #' # Set up the pkgdown website including a vignette page
 #'  setup_website(has_example = TRUE)
-#' }
-#' \dontshow{
-#' setwd(.old_wd)
 #' }
 setup_website <- function(has_example=FALSE){
   # Check on README file

--- a/R/update_citation.R
+++ b/R/update_citation.R
@@ -1,32 +1,33 @@
 #' Update the citation file for the dataset.
 #'
 #' @description
-#' Create a citation *.cff file for the released dataset from a given DOI(Digital
-#' Object Identifier). It adds the DOI badge to the README RMarkdown file and
-#' re-build the README.md and pkgdown website if exists.
+#' Create a citation *.cff file for the dataset from a given DOI (Digital
+#' Object Identifier). When a DOI is supplied, it adds the DOI badge to the
+#' README RMarkdown file and re-builds the README.md and pkgdown website if
+#' they exist. Before a release exists, call it without arguments to generate
+#' the citation files without a DOI or badge.
 #'
-#' @param doi DOI(Digital Object Identifier), e.g., 10.5281/zenodo.11185699
+#' @param doi DOI (Digital Object Identifier), e.g., 10.5281/zenodo.11185699.
+#'   Defaults to NULL for the pre-release call, in which case no DOI is
+#'   recorded and no badge is added.
 #'
 #' @returns NULL. A citation .cff file is written under the root directory.
 #' @export
 #'
 #' @examples
-#' \dontshow{
-#' .old_wd <- setwd(tempdir())
-#' }
 #' \dontrun{
 #'   update_citation(doi = "10.5281/zenodo.11185699")
 #' }
-#' \dontshow{
-#' setwd(.old_wd)
-#' }
 #'
-update_citation <- function(doi){
+update_citation <- function(doi = NULL){
   # Creates CFF with all author roles
+  keys <- list("date-released" = desc::desc_get("Date"))
+  if (!is.null(doi)) {
+    keys$doi <- doi
+  }
   mod_cff <- cffr::cff_create("DESCRIPTION",
                         dependencies = FALSE,
-                        keys = list("doi" = doi,
-                                    "date-released" = desc::desc_get("Date")))
+                        keys = keys)
 
   # Remove the preferred-citation key
   mod_cff$`preferred-citation` <- NULL
@@ -42,8 +43,15 @@ update_citation <- function(doi){
 
   cffr::cff_write_citation(a_cff, file = path_cit)
 
+  # cffr backs up an existing file as *.bk1 before overwriting; drop the
+  # backups so they cannot slip into release commits
+  backups <- c(Sys.glob("CITATION.cff.bk*"), Sys.glob(file.path("inst", "CITATION.bk*")))
+  if (length(backups) > 0) {
+    unlink(backups)
+  }
+
   # Modify README and pkgdown
-  if(file.exists(file.path("README.Rmd"))){
+  if(!is.null(doi) && file.exists(file.path("README.Rmd"))){
     add_citation_badge(doi)
     devtools::build_readme()
   }
@@ -63,12 +71,23 @@ add_citation_badge<- function(doi){
   readme_rmd_path <- file.path("README.Rmd")
   readme_rmd <- readLines(readme_rmd_path)
 
-  i <- 1
-  line <- readme_rmd[1]
-  while (!startsWith(line, prefix = "<!-- badges: end -->")) {
-    i <- i+1
-    line <- readme_rmd[i]
+  end_marker <- which(startsWith(readme_rmd, "<!-- badges: end -->"))
+  if (length(end_marker) == 0) {
+    usethis::ui_stop("No '<!-- badges: end -->' marker found in README.Rmd.
+                      Please add the badge markers before updating the citation.")
   }
-  new_readme_rmd <- c(readme_rmd[1:i-1], badge_str, readme_rmd[i:length(readme_rmd)])
+
+  existing <- which(grepl("[![DOI](https://zenodo.org/badge/DOI/", readme_rmd, fixed = TRUE))
+  if (length(existing) > 0) {
+    # Replace the existing badge in place so re-runs stay idempotent
+    readme_rmd[existing[1]] <- badge_str
+    if (length(existing) > 1) {
+      readme_rmd <- readme_rmd[-existing[-1]]
+    }
+    new_readme_rmd <- readme_rmd
+  } else {
+    i <- end_marker[1]
+    new_readme_rmd <- c(readme_rmd[seq_len(i - 1)], badge_str, readme_rmd[i:length(readme_rmd)])
+  }
   writeLines(new_readme_rmd, readme_rmd_path)
 }

--- a/R/update_description.R
+++ b/R/update_description.R
@@ -4,6 +4,9 @@
 #' @description
 #' This function updates the DESCRIPTION file of an R package to comply with openwashdata standards.
 #' It ensures that fields such as `License`, `Language`, `Date`, `URL`, and others are correctly specified.
+#' Existing `URL` and `Config/Needs/website` entries are preserved and merged
+#' with the openwashdata defaults. A CC BY 4.0 license is only set when the
+#' package does not have a license yet; an existing license is left untouched.
 #'
 #' @param file Character. The file path to the DESCRIPTION file of the R package. Defaults to the current working directory.
 #' @param github_user Character. The URL path to the GitHub user or organization that hosts the current package. Defaults to "https://github.com/openwashdata".
@@ -25,14 +28,19 @@
 #'
 #'
 update_description <- function(file = ".", github_user = "https://github.com/openwashdata/"){
-  if(!file.exists(file.path(getwd(), "DESCRIPTION"))){
+  desc_path <- if (dir.exists(file)) file.path(file, "DESCRIPTION") else file
+  if(!file.exists(desc_path)){
     usethis::ui_stop("No DESCRIPTION file found!")
   }
   pkgname <- desc::desc_get("Package", file = file)[[1]]
   # author
 
-  # license
-  usethis::use_ccby_license()
+  # license: set CC BY 4.0 only when no license is present yet; the usethis
+  # call acts on the active project, so it only runs for the default file
+  license <- desc::desc_get_field("License", default = "", file = file)
+  if (file == "." && (identical(license, "") || grepl("use_mit_license", license, fixed = TRUE))) {
+    usethis::use_ccby_license()
+  }
 
   # language
   desc::desc_set("Language", "en-GB", file = file)
@@ -40,14 +48,20 @@ update_description <- function(file = ".", github_user = "https://github.com/ope
 
   # Other Fields
   desc::desc_set("LazyData", "true", file = file)
-  desc::desc_set("Config/Needs/website", "rmarkdown", file = file)
+  # Config/Needs/website: merge with existing entries instead of replacing
+  website <- desc::desc_get_field("Config/Needs/website", default = "", file = file)
+  website <- setdiff(trimws(strsplit(website, ",")[[1]]), "")
+  desc::desc_set("Config/Needs/website",
+                 paste(union("rmarkdown", website), collapse = ", "),
+                 file = file)
 
   # Date
   desc::desc_set("Date",
                  Sys.Date(),
                  file = file)
-  # URL
-  desc::desc_set_urls(urls = c(paste0(github_user, pkgname)),
+  # URL: merge with existing entries instead of replacing
+  urls <- union(desc::desc_get_urls(file = file), paste0(github_user, pkgname))
+  desc::desc_set_urls(urls = urls,
                       file = file)
   # Bug Reports
   desc::desc_set("BugReports",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,17 +1,22 @@
-## Version 1.0.0
+## Version 1.0.2
 
-Initial submission to CRAN.
+This is a patch release containing bug fixes only, with no new API.
 
-## Resubmission (V1.0.1)
+### Maintainer change
 
-This is a resubmission. Following the suggestions of the reviewer I have:
+The previous maintainer, Colin Walder, has left ETH Zurich and his email
+address is no longer active. The new maintainer, Lars Schöbitz
+(lschoebitz@ethz.ch), is a package co-author and works at the same
+institution (Global Health Engineering, ETH Zurich), which holds the
+copyright. Colin Walder remains a package author.
 
-* Moved CODE_OF_CONDUCT.md to inst/*.
-* Deleted the line "+ file LICENSE" and the corresponding file.
-* Removed a potentially misleading term/word ("openwashdata") in DESCRIPTION.
+### Changes
+
+- Six bug fixes to `update_citation()`, `update_description()`, and
+  `setup_readme()`, each with a regression test (see NEWS.md).
+- Removed example blocks that wrote to the temporary directory at check
+  time, and fixed an example that referenced a nonexistent function.
 
 ### R CMD check results
 
-0 errors | 0 warnings | 1 note
-
-devtools::check() returns one note: unable to verify current time.
+0 errors | 0 warnings | 0 notes

--- a/man/fill_dictionary.Rd
+++ b/man/fill_dictionary.Rd
@@ -18,14 +18,8 @@ A tibble data frame of dataset dictionary with an empty description column to be
 Fill in the dictionary file based on the tidy data information
 }
 \examples{
-\dontshow{
-.old_wd <- setwd(tempdir())
-}
 \dontrun{
-update_dictionary(dict_path = "data-raw/my-dictionary.csv", data = "data/")
-}
-\dontshow{
-setwd(.old_wd)
+fill_dictionary(dict_path = "data-raw/dictionary.csv", data_dir = "data/")
 }
 
 }

--- a/man/setup_dictionary.Rd
+++ b/man/setup_dictionary.Rd
@@ -17,18 +17,10 @@ variable types, and descriptions. If tidy data exists, the dictionary is populat
 relevant information; otherwise, it creates an empty dictionary CSV file.
 }
 \examples{
-\dontshow{
-temppkg <- tempdir()
-devtools::create(temppkg, open=FALSE)
-.old_wd <- setwd(temppkg)
-}
 \dontrun{
 setup_rawdata()
 # Go to data_processing.R, clean the raw data and export tidy data
 setup_dictionary()
-}
-\dontshow{
-setwd(.old_wd)
 }
 
 }

--- a/man/setup_readme.Rd
+++ b/man/setup_readme.Rd
@@ -4,7 +4,11 @@
 \alias{setup_readme}
 \title{Generate the README RMarkdown file}
 \usage{
-setup_readme()
+setup_readme(force = FALSE)
+}
+\arguments{
+\item{force}{Logical. If FALSE (the default), the function stops when a
+README.Rmd already exists. Set to TRUE to overwrite the existing file.}
 }
 \value{
 NULL. This function creates a README.Rmd under the package directory.

--- a/man/setup_roxygen.Rd
+++ b/man/setup_roxygen.Rd
@@ -25,18 +25,10 @@ in the Roxygen documentation files within R/ directory. The title and descriptio
 unchanged.
 }
 \examples{
-\dontshow{
-temppkg <- tempdir()
-devtools::create(temppkg, open=FALSE)
-.old_wd <- setwd(temppkg)
-}
 \dontrun{
 setup_dictionary()
 # Once the dictionary is created, go to data-raw/dictionary.csv and complete the column description.
 setup_roxygen()
-}
-\dontshow{
-setwd(.old_wd)
 }
 
 }

--- a/man/setup_website.Rd
+++ b/man/setup_website.Rd
@@ -19,14 +19,8 @@ based on its README.md file. The website provides a structured and visually appe
 of the package's documentation.
 }
 \examples{
-\dontshow{
-.old_wd <- setwd(tempdir())
-}
 \dontrun{
 # Set up the pkgdown website including a vignette page
  setup_website(has_example = TRUE)
-}
-\dontshow{
-setwd(.old_wd)
 }
 }

--- a/man/update_citation.Rd
+++ b/man/update_citation.Rd
@@ -4,28 +4,26 @@
 \alias{update_citation}
 \title{Update the citation file for the dataset.}
 \usage{
-update_citation(doi)
+update_citation(doi = NULL)
 }
 \arguments{
-\item{doi}{DOI(Digital Object Identifier), e.g., 10.5281/zenodo.11185699}
+\item{doi}{DOI (Digital Object Identifier), e.g., 10.5281/zenodo.11185699.
+Defaults to NULL for the pre-release call, in which case no DOI is
+recorded and no badge is added.}
 }
 \value{
 NULL. A citation .cff file is written under the root directory.
 }
 \description{
-Create a citation *.cff file for the released dataset from a given DOI(Digital
-Object Identifier). It adds the DOI badge to the README RMarkdown file and
-re-build the README.md and pkgdown website if exists.
+Create a citation *.cff file for the dataset from a given DOI (Digital
+Object Identifier). When a DOI is supplied, it adds the DOI badge to the
+README RMarkdown file and re-builds the README.md and pkgdown website if
+they exist. Before a release exists, call it without arguments to generate
+the citation files without a DOI or badge.
 }
 \examples{
-\dontshow{
-.old_wd <- setwd(tempdir())
-}
 \dontrun{
   update_citation(doi = "10.5281/zenodo.11185699")
-}
-\dontshow{
-setwd(.old_wd)
 }
 
 }

--- a/man/update_description.Rd
+++ b/man/update_description.Rd
@@ -20,6 +20,9 @@ NULL. Update fields directly in DESCRIPTION file.
 \description{
 This function updates the DESCRIPTION file of an R package to comply with openwashdata standards.
 It ensures that fields such as \code{License}, \code{Language}, \code{Date}, \code{URL}, and others are correctly specified.
+Existing \code{URL} and \code{Config/Needs/website} entries are preserved and merged
+with the openwashdata defaults. A CC BY 4.0 license is only set when the
+package does not have a license yet; an existing license is left untouched.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/_snaps/update_citation.md
+++ b/tests/testthat/_snaps/update_citation.md
@@ -1,0 +1,28 @@
+# CITATION.cff full-file snapshot (#65)
+
+    Code
+      cat(cff, sep = "\n")
+    Output
+      # ------------------------------------------------
+      # CITATION.cff file created with {cffr} R package
+      # See also: https://docs.ropensci.org/cffr/
+      # ------------------------------------------------
+       
+      cff-version: 1.2.0
+      message: 'To cite package "PKGNAME" in publications use:'
+      type: software
+      title: 'PKGNAME: What the Package Does (One Line, Title Case)'
+      version: 0.0.0.9000
+      doi: 10.5281/zenodo.11185699
+      abstract: What the package does (one paragraph).
+      authors:
+      - family-names: Last
+        given-names: First
+        email: first.last@example.com
+      date-released: '2026-07-23'
+      contact:
+      - family-names: Last
+        given-names: First
+        email: first.last@example.com
+      
+

--- a/tests/testthat/_snaps/update_description.md
+++ b/tests/testthat/_snaps/update_description.md
@@ -1,0 +1,24 @@
+# DESCRIPTION full-file snapshot (#65)
+
+    Code
+      cat(lines, sep = "\n")
+    Output
+      Package: PKGNAME
+      Title: What the Package Does (One Line, Title Case)
+      Version: 0.0.0.9000
+      Authors@R: 
+          person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
+      Description: What the package does (one paragraph).
+      License: CC BY 4.0
+      Config/testthat/edition: 3
+      Encoding: UTF-8
+      Roxygen: list(markdown = TRUE)
+      RoxygenNote: SCRUBBED
+      Config/Needs/website: rmarkdown, leaflet
+      URL: https://openwashdata.github.io/testpkg/,
+          https://github.com/openwashdata/PKGNAME
+      Language: en-GB
+      LazyData: true
+      Date: YYYY-MM-DD
+      BugReports: https://github.com/openwashdata/PKGNAME/issues
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -18,19 +18,14 @@ create_local_thing <- function(dir = tempfile(pattern = pattern),
                                thing = c("package", "project")) {
   thing <- match.arg(thing)
   if (dir.exists(dir)) {
-    ui_abort("Target {.arg dir} {.path {pth(dir)}} already exists.")
+    stop("Target dir ", dir, " already exists.")
   }
 
-  old_project <- usethis:::proj_get_() # this could be `NULL`, i.e. no active project
+  # could be `NULL`, i.e. no active project
+  old_project <- tryCatch(usethis::proj_get(), error = function(e) NULL)
   old_wd <- getwd()          # not necessarily same as `old_project`
 
-  withr::defer(
-    {
-      print("Deleting temporary project: {.path {dir}}")
-      unlink(dir, recursive = TRUE)
-    },
-    envir = env
-  )
+  withr::defer(unlink(dir, recursive = TRUE), envir = env)
 
   switch(
       thing,
@@ -46,19 +41,13 @@ create_local_thing <- function(dir = tempfile(pattern = pattern),
         open = FALSE,
         check_name = FALSE
       ),
-      project = create_project(dir, rstudio = rstudio, open = FALSE)
+      project = usethis::create_project(dir, rstudio = rstudio, open = FALSE)
     )
 
   withr::defer(usethis::proj_set(old_project, force = TRUE), envir = env)
   usethis::proj_set(dir)
 
-  withr::defer(
-    {
-      print("Restoring original working directory: {.path {old_wd}}")
-      setwd(old_wd)
-    },
-    envir = env
-  )
+  withr::defer(setwd(old_wd), envir = env)
   setwd(usethis::proj_get())
 
   invisible(usethis::proj_get())

--- a/tests/testthat/test_setup_rawdata.R
+++ b/tests/testthat/test_setup_rawdata.R
@@ -3,7 +3,6 @@ test_that("File and directory are created", {
   create_local_package()
 
   rlang::local_interactive(FALSE)
-  print(getwd())
   washr::setup_rawdata()
   expect_true(file.exists("data-raw/data_processing.R"))
 })

--- a/tests/testthat/test_setup_readme.R
+++ b/tests/testthat/test_setup_readme.R
@@ -13,3 +13,24 @@ test_that("setup_readme runs when there is data objects", {
   usethis::use_data(d1)
   expect_no_error(setup_readme())
 })
+
+test_that("setup_readme refuses to overwrite an existing README.Rmd (#64)", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  d1 <- data.frame(id = 1:3, name = c("A", "B", "C"))
+  usethis::use_data(d1)
+  writeLines(c("# HAND-WRITTEN README", "do not lose this"), "README.Rmd")
+  before <- readLines("README.Rmd")
+  expect_error(setup_readme(), "force")
+  expect_identical(readLines("README.Rmd"), before)
+})
+
+test_that("setup_readme(force = TRUE) overwrites an existing README.Rmd", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  d1 <- data.frame(id = 1:3, name = c("A", "B", "C"))
+  usethis::use_data(d1)
+  writeLines("# OLD README", "README.Rmd")
+  expect_no_error(setup_readme(force = TRUE))
+  expect_false(identical(readLines("README.Rmd"), "# OLD README"))
+})

--- a/tests/testthat/test_update_citation.R
+++ b/tests/testthat/test_update_citation.R
@@ -1,0 +1,73 @@
+options(usethis.quiet = TRUE)
+
+# TEST update_citation ---------------------------------------------------------
+test_that("update_citation() runs without a doi (#57)", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  desc::desc_set("Date", "2026-07-23")
+  expect_no_error(suppressMessages(update_citation()))
+  expect_true(file.exists("CITATION.cff"))
+  expect_true(file.exists(file.path("inst", "CITATION")))
+  expect_false(any(grepl("^doi:", readLines("CITATION.cff"))))
+})
+
+test_that("update_citation(doi = NULL) does not inject an empty DOI badge (#58)", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  desc::desc_set("Date", "2026-07-23")
+  writeLines(c("# pkg", "<!-- badges: start -->", "<!-- badges: end -->"),
+             "README.Rmd")
+  suppressMessages(update_citation(doi = NULL))
+  expect_false(any(grepl("zenodo.org/badge/DOI", readLines("README.Rmd"),
+                         fixed = TRUE)))
+})
+
+test_that("update_citation() leaves no .bk1 backup files behind (#60)", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  desc::desc_set("Date", "2026-07-23")
+  suppressMessages(update_citation(doi = "10.5281/zenodo.11185699"))
+  suppressMessages(update_citation(doi = "10.5281/zenodo.11185699"))
+  expect_length(list.files(".", pattern = "\\.bk[0-9]+$", recursive = TRUE), 0)
+})
+
+test_that("add_citation_badge() errors clearly without the badges-end marker", {
+  create_local_package()
+  writeLines(c("# pkg", "no badge markers here"), "README.Rmd")
+  expect_error(add_citation_badge("10.5281/zenodo.11185699"), "badges: end")
+})
+
+test_that("add_citation_badge() replaces an existing DOI badge instead of duplicating", {
+  create_local_package()
+  writeLines(c("# pkg", "<!-- badges: start -->", "<!-- badges: end -->"),
+             "README.Rmd")
+  add_citation_badge("10.5281/zenodo.111")
+  add_citation_badge("10.5281/zenodo.222")
+  badges <- grep("zenodo.org/badge/DOI", readLines("README.Rmd"),
+                 fixed = TRUE, value = TRUE)
+  expect_length(badges, 1)
+  expect_match(badges, "zenodo.222", fixed = TRUE)
+})
+
+test_that("add_citation_badge() heals a broken empty badge left by 1.0.1 (#58)", {
+  create_local_package()
+  writeLines(c("# pkg", "<!-- badges: start -->",
+               "[![DOI](https://zenodo.org/badge/DOI/.svg)](https://zenodo.org/doi/)",
+               "<!-- badges: end -->"),
+             "README.Rmd")
+  add_citation_badge("10.5281/zenodo.333")
+  badges <- grep("zenodo.org/badge/DOI", readLines("README.Rmd"),
+                 fixed = TRUE, value = TRUE)
+  expect_length(badges, 1)
+  expect_match(badges, "zenodo.333", fixed = TRUE)
+})
+
+test_that("CITATION.cff full-file snapshot (#65)", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  desc::desc_set("Date", "2026-07-23")
+  suppressMessages(update_citation(doi = "10.5281/zenodo.11185699"))
+  pkgname <- desc::desc_get("Package")[[1]]
+  cff <- gsub(pkgname, "PKGNAME", readLines("CITATION.cff"), fixed = TRUE)
+  expect_snapshot(cat(cff, sep = "\n"))
+})

--- a/tests/testthat/test_update_description.R
+++ b/tests/testthat/test_update_description.R
@@ -1,7 +1,77 @@
 options(usethis.quiet = TRUE)
-test_that("DESCRIPTION file is updated", {
+
+# TEST update_description ------------------------------------------------------
+test_that("update_description() sets the openwashdata fields", {
   create_local_package()
   rlang::local_interactive(FALSE)
-  washr::update_description()
-  expect_true(file.exists("DESCRIPTION"))
+  pkgname <- desc::desc_get("Package")[[1]]
+  update_description()
+  expect_equal(desc::desc_get("Language")[[1]], "en-GB")
+  expect_equal(desc::desc_get("LazyData")[[1]], "true")
+  expect_equal(desc::desc_get("Date")[[1]], as.character(Sys.Date()))
+  expect_true(paste0("https://github.com/openwashdata/", pkgname)
+              %in% desc::desc_get_urls())
+  expect_equal(desc::desc_get("BugReports")[[1]],
+               paste0("https://github.com/openwashdata/", pkgname, "/issues"))
+})
+
+test_that("update_description() sets CC BY 4.0 when no license is present", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  update_description()
+  expect_equal(desc::desc_get("License")[[1]], "CC BY 4.0")
+})
+
+test_that("update_description() preserves an existing license (#63)", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  desc::desc_set("License", "GPL (>= 3)")
+  update_description()
+  expect_equal(desc::desc_get("License")[[1]], "GPL (>= 3)")
+  expect_false(file.exists("LICENSE.md"))
+})
+
+test_that("update_description() preserves existing URL entries (#63)", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  desc::desc_set_urls("https://openwashdata.github.io/testpkg/")
+  update_description()
+  urls <- desc::desc_get_urls()
+  expect_true("https://openwashdata.github.io/testpkg/" %in% urls)
+  expect_true(any(grepl("github.com/openwashdata/", urls, fixed = TRUE)))
+})
+
+test_that("update_description() merges Config/Needs/website entries (#59)", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  desc::desc_set("Config/Needs/website",
+                 "rmarkdown, leaflet, htmlwidgets, webshot2")
+  update_description()
+  entries <- trimws(strsplit(desc::desc_get_field("Config/Needs/website"),
+                             ",")[[1]])
+  expect_setequal(entries,
+                  c("rmarkdown", "leaflet", "htmlwidgets", "webshot2"))
+})
+
+test_that("update_description() honors the file argument (#63)", {
+  pkg <- create_local_package()
+  rlang::local_interactive(FALSE)
+  desc::desc_set("License", "GPL (>= 3)")
+  withr::local_dir(withr::local_tempdir())
+  expect_no_error(update_description(file = pkg))
+  expect_equal(desc::desc_get("Language", file = pkg)[[1]], "en-GB")
+})
+
+test_that("DESCRIPTION full-file snapshot (#65)", {
+  create_local_package()
+  rlang::local_interactive(FALSE)
+  desc::desc_set("Config/Needs/website", "rmarkdown, leaflet")
+  desc::desc_set_urls("https://openwashdata.github.io/testpkg/")
+  update_description()
+  pkgname <- desc::desc_get("Package")[[1]]
+  lines <- readLines("DESCRIPTION")
+  lines <- gsub(pkgname, "PKGNAME", lines, fixed = TRUE)
+  lines <- gsub(as.character(Sys.Date()), "YYYY-MM-DD", lines, fixed = TRUE)
+  lines <- sub("^RoxygenNote:.*$", "RoxygenNote: SCRUBBED", lines)
+  expect_snapshot(cat(lines, sep = "\n"))
 })


### PR DESCRIPTION
Completes the forward-merge gate from #66. PR #89 (release/1.0.2 into main) shows merge conflicts because main's metadata work diverged from the 1.0.1 CRAN state the release branch was cut from. Resolving those conflicts by merging main into release/1.0.2 would contaminate the CRAN submission base, so the resolution lives here instead: a merge of release/1.0.2 into main done on the main side. Merging this PR makes the release branch tip reachable from main, which marks #89 merged automatically; release/1.0.2 itself stays untouched.

## Conflict resolution

- DESCRIPTION: main's expanded structure kept (full Imports list, reflowed Description); release side wins Version 1.0.2, the maintainer change (Colin Walder aut, Lars Schoebitz aut + cre), Date 2026-07-23, and the roxygen2 8.0.0 version field. The Authors@R block auto-merged.
- R/update_citation.R: release side taken wholesale (doi optional, idempotent badge insertion, clear badges-end-marker error, cffr backup cleanup). Main's changes to this file were cosmetic formatting only, fully superseded by the rewrite and covered by the new regression tests.

## Version bump

Second commit bumps main to 1.0.2.9000 with a development-version NEWS.md heading, per the #89 notes: main carries unreleased exports beyond the 1.0.2 CRAN state, so it moves past the release version after the merge.

## Verification

- devtools::test() on the merged tree: 52 pass, 0 fail, 0 warnings
- R CMD check (local, --no-manual): 0 errors, 0 warnings, 0 notes

CRAN submission still happens from release/1.0.2 after the #61 maintainer handover is confirmed; this PR only closes the forward-merge gate so the fixes and tests cannot be lost in the 1.1.0 rework.
