### PR TITLE
docs: journal strategy documents (critique, three-phase approach, research reports)

### DIFF
--- a/dev/journal-2026-07/journal-plan-critique-and-approach.md
+++ b/dev/journal-2026-07/journal-plan-critique-and-approach.md
@@ -1,0 +1,241 @@
+# openwashdata journal: plan critique and structured approach
+
+Date: 2026-07-26
+Status: strategy document, decision-support for the maintainer (Lars). No code changes implied for washr v1.0.2/v1.1.0 scope.
+Companion evidence: `research-data-journals.md`, `research-submission-governance.md`, `research-openwashdata-ecosystem.md` in this directory.
+
+## The plan under critique
+
+Add a CRAN-like submission layer to the openwashdata catalogue (defined maintainer with
+email, terms of reference clarifying responsibility) as preparation for an openwashdata
+journal — a data journal for WASH with an eventual impact factor, so that researchers and
+practitioners get credit for primary raw data, on the thesis that written articles are
+becoming mechanical to produce while original raw data becomes the scarce, valuable input.
+
+## Verdict in one paragraph
+
+The submission layer is unambiguously right and should be built regardless of the journal
+— it formalizes what CRAN already forces on washr itself and what pkgreview already
+sketches, and it closes gaps that are visible from the outside today (no maintenance
+policy, maintainers hidden, no contributor agreement, no versioning policy). The journal
+is a real gap with genuinely good timing, but the plan as stated contains one structural
+tension that must be resolved by design, not discovered later: the lightweight
+GitHub-native model that fits openwashdata's community (JOSS-style) is precisely the model
+that has failed for ten years to obtain an impact factor, while the impact factor is the
+stated core incentive. Both are achievable, but only if the journal is deliberately built
+to look conventional to Clarivate/Scopus while operating openly — and only if throughput
+(~20–25 reviewed publications/year) can be sustained, which at the catalogue's current
+rate (~17 datasets/year, heavily concentrated on few maintainers) is not yet true.
+
+## A. What the evidence supports (strengths of the plan)
+
+1. **The gap is real.** No WASH-specific data journal exists. The sector flagship
+   (Journal of Water, Sanitation and Hygiene for Development, IWA) has no data-paper
+   article type. WASH datasets currently route to Data in Brief (~$1,240 APC) or
+   Scientific Data (~$2,190 APC) — fee walls that exclude exactly the Global South
+   practitioners openwashdata serves.
+
+2. **Funder timing favors a diamond-OA venue.** The Gates Foundation 2025 OA policy
+   stopped paying APCs entirely and mandates open data. A zero-fee data journal is
+   aligned with where the biggest WASH funder is pushing.
+
+3. **The impact factor is more attainable than JOSS's history suggests — via one
+   specific door.** Since the 2023 JCR, every journal in Web of Science ESCI receives an
+   impact factor. ESCI has 24 quality criteria but they are procedural (ISSN, named
+   editorial board with affiliations, documented peer review policy, ethics statements,
+   timely regular publication, international authorship) — not "be Nature". Realistic
+   timeline: ~2 years of regular publishing + 1–2 years evaluation = first IF in year
+   3–5. Scopus's fixed 2-year history rule was dropped in 2024, but real acceptance of
+   suggested titles is under 20%.
+
+4. **Most of the machinery already exists in-house.** washr scaffolds the artifact;
+   pkgreview's tiered checklist and GitHub-issue reviews (e.g. solidwastekampala#17) are
+   a proto-editorial process; Zenodo DOIs exist for 40/50 published packages; JOSS's
+   editorialbot is open source and already reused by rOpenSci. openwashdata is closer to
+   JOSS-grade mechanics than almost any journal founder ever is at this stage.
+
+5. **The core value thesis is directionally sound.** Data descriptors are largely
+   mechanical given a well-documented dataset — a washr package with a complete
+   dictionary, README and metadata nearly *is* the data paper. That is an asymmetric
+   advantage: the marginal cost of a paper on top of a reviewed openwashdata package is
+   close to zero, which no incumbent data journal can match.
+
+## B. Where the plan is exposed (weaknesses and blind spots)
+
+1. **The JOSS paradox — the central tension.** JOSS is free, GitHub-based, credible,
+   heavily cited, and after a decade still has no impact factor because Scopus/WoS view
+   its checklist-driven open review as unconventional. You cannot copy JOSS's mechanics
+   wholesale and also promise an IF. Resolution: keep the open GitHub review as the
+   *mechanism*, but wrap it in the conventional *form* indexers evaluate — named
+   editorial board, formally documented two-reviewer policy, editorial decisions recorded
+   per article, ISSN, regular volumes, COPE-aligned ethics pages, archival arrangement.
+   ESSD proves open interactive review can carry an IF (13.6) when the editorial form is
+   conventional.
+
+2. **Throughput is the binding constraint, not money.** JOSS's marginal cost is ~$3–6
+   per paper; money is a non-issue. But a journal publishing under ~20 papers/year looks
+   dead to indexers and authors. The catalogue has published 50 datasets in ~3 years, 17
+   of 50 by a single maintainer, and the intake funnel is untested as a review pipeline.
+   Journal of Open Humanities Data manages ~76 articles/year with an entire discipline
+   behind it. The ds4owd academy (40+ graduates/cohort, each required to bring a
+   dataset) is the credible pipeline — but conversion from "graduate with dataset" to
+   "reviewed publication" is unproven. The go/no-go for the journal must be a measured
+   throughput gate, not enthusiasm.
+
+3. **The maintainer requirement is necessary but insufficient — washr's own history
+   proves it.** The v1.0.2 release was gated on exactly this failure: CRAN mail going to
+   a departed maintainer's dead mailbox (premortem R2). WASH practitioners and NGO staff
+   churn faster than academics. A CRAN-style "one person, one email" rule will fail
+   routinely. The policy needs, from day one: an institutional fallback contact
+   (DataCite's `ContactPerson` contributor type explicitly supports organizational
+   contacts), a succession path (rOpenSci documents maintainer handover; Bioconductor
+   runs a staged one-year end-of-life for unresponsive maintainers), and archival-not-
+   deletion as the end state. openwashdata itself (the org) must be the maintainer of
+   last resort, and the ToR must say so.
+
+4. **Single-maintainer bandwidth — your own premortems' top risk — scales worst in a
+   journal.** Both the washr and pkgreview premortems independently named maintainer
+   bandwidth the most likely failure for ordinary package milestones. A journal is an
+   editorial commitment with no ship date and volunteer burnout is the documented killer
+   of small journals. The mitigations are structural: an editorial board that actually
+   handles submissions (not a letterhead board), bot automation for everything checkable
+   (the `check_publication_readiness()` gate, #82, is the R CMD check analog), and a
+   paid managing-editor fraction — which is exactly what the ORD Phase 2 "data stewards"
+   proposal could fund.
+
+5. **The impact-factor thesis has a hedging problem.** By the time a first IF can arrive
+   (realistically 2030±1), data-citation infrastructure (DataCite Event Data, Make Data
+   Count) and funder mandates may have shifted how data credit is counted; conversely,
+   hiring committees still read journal lines today and will for years. Both halves
+   matter: the journal's value proposition must stand *without* the IF (DOI, citable
+   venue, peer-review quality signal, discoverability, community), with the IF treated
+   as an option that arrives later — not the promise made to early authors. Never market
+   the IF before it exists; that is the predatory-journal tell.
+
+6. **Three layers are being conflated, and they have different clocks.** (a) The
+   submission/maintainership layer — cheap, needed now, valuable even if no journal ever
+   launches. (b) The editorial review process — pkgreview formalized into published
+   review criteria with external reviewers; valuable standalone as a "certified
+   catalogue". (c) The journal wrapper — ISSN, paper DOIs, editorial board, indexing
+   applications; a separate, gated decision. Building them as one bet risks the whole
+   stack on the hardest layer. Built as a→b→c, each layer de-risks the next and (c) can
+   be abandoned without losing (a) and (b).
+
+7. **Smaller factual gaps to close on the way** (from the ecosystem scan): 10 published
+   packages lack DOIs; maintainers are tracked internally but not displayed publicly;
+   Zenodo records are not indexed by Google Scholar (a data *paper* with a Crossref DOI
+   fixes discoverability that datasets alone don't get); there is no stated versioning
+   policy; the guide's ETH Research Collection path applies only to GHE-internal
+   submissions.
+
+## C. Structured approach
+
+### Phase 1 — Submission layer ("the CRAN layer"), target: alongside the September 2026 milestones
+
+Deliverable is one public policy document plus small mechanical changes. Do not let it
+balloon into the journal.
+
+1. **Write the openwashdata Dataset Publication Policy (the terms of reference).** One
+   page-scale document, CRAN-policy style, versioned in a public repo. Contents:
+   - **Maintainer**: every dataset names one maintainer with a monitored email
+     (DESCRIPTION `cre`, surfaced as DataCite `ContactPerson`), plus a required
+     institutional fallback contact; openwashdata is maintainer of last resort.
+   - **Obligations**: respond to data issues within a stated window (e.g. 4 weeks);
+     keep contact details current; a bouncing address starts the clock on the
+     end-of-life process.
+   - **End-of-life/succession** (Bioconductor template): staged outreach → public call
+     for a new maintainer (rOpenSci pattern) → archival with the DOI and record kept
+     citable. Archive, never delete.
+   - **Floor requirements**: CC BY 4.0 (or opt-out justification), complete dictionary,
+     passing `R CMD check`, DOI minted before "published" status, PII screening
+     attestation (pkgreview already has the PII chapter).
+   - **Versioning**: semantic dataset versioning; Zenodo versioned DOIs; what
+     constitutes a new version vs a new dataset.
+   - **Responsibility split**: what the maintainer warrants (provenance, consent/PII,
+     license authority) vs what openwashdata provides (hosting, tooling, review,
+     archival). This is the clause that protects both sides and is currently absent.
+2. **Mechanical changes, mostly already planned**: surface the maintainer + DOI in the
+   public catalogue table (data exists in the sheet already); mint the 10 missing DOIs;
+   `check_publication_readiness()` (#82) becomes the automated submission gate; the
+   intake issue template on openwashdata/data gains the policy checklist (maintainer,
+   fallback contact, license authority, PII attestation).
+3. **Explicitly out of scope**: anything requiring new services, the journal name, ISSN.
+   The washr v1.0.2/v1.1.0 plan is already full; this phase consumes policy-writing
+   bandwidth, not engineering bandwidth.
+
+### Phase 2 — Editorial layer ("the rOpenSci layer"), 2027
+
+Formalize what pkgreview already does into something that reads as peer review to an
+outsider.
+
+1. Publish the **review criteria** as a standalone document: merge pkgreview's tiers
+   with the Data Curation Network CURATE(D) checklist and ESSD's three reviewer
+   questions (significant/complete? usable with adequate metadata? claims evaluable?).
+2. **Two-named-reviewer open review** on GitHub issues (rOpenSci/ESSD hybrid): one
+   technical (runs the checks — largely bot-assisted), one domain (WASH substance).
+   Editor role assigns and closes. Every accepted dataset gets a citable review record.
+3. **Recruit 3–5 handling editors** now, not at journal launch: ds4owd graduates + the
+   Phase 2 data stewards + 1–2 external WASH academics. This is also the future
+   editorial board forming, and the earliest test of whether the volunteer pool exists.
+4. **Pilot**: run ~10 datasets (mix of new intake and existing fleet) through the full
+   pipeline in two quarters. Measure: elapsed time, editor-hours per dataset, reviewer
+   acceptance rate when asked. These numbers are the Phase 3 gate.
+
+### Phase 3 — Journal wrapper, decision gated (~2028)
+
+**Gate to launch** (all three, measured, not vibes): sustained reviewed throughput ≥
+20/year for two consecutive quarters; ≥ 3 active handling editors who are not Lars;
+funding line for a managing-editor fraction (ORD Phase 2 or successor). If the gate
+fails, stop at Phase 2 — a certified, reviewed catalogue with DOIs is a respectable
+permanent end state, and nothing from Phases 1–2 is wasted.
+
+If launched:
+
+1. **Form**: short data descriptors (2–4 pages) generated substantially from the package
+   (README + dictionary + provenance narrative) — washr eventually gains
+   `generate_paper()`; the dataset DOI (Zenodo/DataCite) and the paper DOI (Crossref,
+   $1/article + ~$275/year membership) are distinct and cross-linked. Diamond OA,
+   no fees, ever.
+2. **Infrastructure**: Open Journals stack (editorialbot) or plain Quarto + GitHub —
+   marginal cost per paper is single-digit dollars; Portico/CLOCKSS archival
+   arrangement early (indexers check).
+3. **Conventional shell around open review**: ISSN at launch; publisher of record
+   decided deliberately (ETH library imprint vs association vs foundation — affects
+   perceived independence and continuity); editorial board with international and
+   Global South representation, listed with affiliations; COPE-aligned policies;
+   fixed publication cadence (continuous publication, quarterly issue rollups).
+4. **Indexing sequence**: DOAJ within year 1 (near-free, achievable, the anti-predatory
+   signal); Google Scholar via proper paper metadata (fixes the Zenodo invisibility);
+   apply to Scopus and WoS ESCI after ~2 years of regular publishing; treat the IF as
+   arriving year 4–5 if at all. A failed application triggers an embargo — do not apply
+   early.
+5. **Positioning**: "the venue where WASH data becomes a first-class, peer-reviewed,
+   citable publication — free for authors and readers." The IF is never the pitch until
+   it exists.
+
+### Standing kill criteria (in the house premortem style)
+
+- Phase 1 policy not agreed within 6 weeks of starting: cut to maintainer + EOL clauses
+  only and ship; the rest iterates.
+- Phase 2 pilot shows > ~8 editor-hours per dataset after bot automation: the review
+  design is too heavy for the volunteer pool — simplify the checklist before scaling.
+- Phase 3 gate unmet by end of 2028: park the journal, keep the certified catalogue,
+  revisit yearly.
+- Any pressure to promise the impact factor to prospective authors before a first JCR
+  listing: refuse; it is the predatory-journal tell and would burn the credibility the
+  whole plan depends on.
+
+## D. On the vision itself
+
+The thesis — raw primary data appreciating while article-writing commoditizes — is
+directionally right and is, in fact, an argument that the *packages* are the product and
+the journal is credit infrastructure around them. Two refinements. First, if article
+production is mechanical, a journal whose papers are mechanically derived must locate its
+value precisely in what is *not* mechanical: the review (provenance, consent, methods,
+reusability judgment) and the maintenance contract (a maintained dataset with a
+responsive contact is worth more than a static deposit — no incumbent journal offers
+that; openwashdata can, and Phase 1 is what makes it true). Second, the moat is not the
+impact factor — anyone can eventually get one — it is the workflow-community-stewardship
+stack (washr + academy + data stewards + review) that makes WASH data *maintained* rather
+than merely deposited. The journal converts that stack into academic currency; it should
+never be mistaken for the stack itself.

--- a/dev/journal-2026-07/research-data-journals.md
+++ b/dev/journal-2026-07/research-data-journals.md
@@ -1,0 +1,59 @@
+# Data Journals Landscape: Research Report for an "openwashdata journal"
+
+Research-agent report, 2026-07-26. Companion evidence to `journal-plan-critique-and-approach.md`.
+
+## 1. Existing data journals and their models
+
+| Journal | Publisher / launch | Model | Fees (APC) | Peer review | Indexing / IF | Time to first IF |
+|---|---|---|---|---|---|---|
+| **Scientific Data** | Nature/Springer, 2014 | "Data Descriptors"; data must live in a recognized public repository | ~$2,190 / €1,890 | Closed, editor-managed | SCIE, Scopus, PubMed; **IF ≈ 9.8** (2026) | ~3 yrs (first IF 4.8, June 2017 JCR) |
+| **Earth System Science Data (ESSD)** | Copernicus, 2008 | Data papers with interactive **public discussion review** | ~€1,400 (often waived via institutional agreements) | Open/interactive, 2-stage | SCIE, Scopus; **IF 13.6** (June 2026, 2025 data); JCR Q1 | first IF released **June 2016**, ~7–8 yrs after launch |
+| **Data in Brief** | Elsevier, 2014 | Short "data articles," heavy co-submission pipeline from other Elsevier journals | ~$1,240 | Light, fast (9 days to first decision, 58% acceptance) | Scopus, ESCI, DOAJ, PubMed; **IF ≈ 1.9**, CiteScore low | got IF only after 2023 ESCI change |
+| **Journal of Open Humanities Data** | Ubiquity Press, 2015 | Data papers for humanities; low-cost OA | low APC (Ubiquity model, a few hundred GBP) | Traditional | Scopus (SJR 0.152, Q3–Q4); ~76 articles in 2025; no meaningful IF | n/a |
+| **Geoscience Data Journal** | Wiley/RMetS, 2013 | Data papers linked to repository deposits | ~$2,080 | Traditional | **IF 2.4** | several years |
+| **Biodiversity Data Journal** | Pensoft, 2013 | Data papers + integrated ARPHA publishing pipeline (data-to-paper tooling) | ~$485 | Open review | SCIE; **IF 1.3** (2026), Q3 | first IF ~2021 (~8 yrs) |
+| **JOSS** | Open Journals, 2016 | Software papers; **free, GitHub-based** | **$0 (diamond OA)** | Fully open, checklist-based on GitHub | Crossref DOIs, DOAJ, Google Scholar, NASA ADS; **NOT in Scopus or Web of Science** despite years of trying → **no impact factor** | never (10 yrs and counting) |
+| **JORS** (Journal of Open Research Software) | Ubiquity, 2013 | Software "metapapers" | ~£350 | Traditional | Scopus, DOAJ; no WoS IF | n/a |
+
+Key pattern: data journals with impact factors are all run by established publishers with APCs of $500–$2,200. The zero-fee, GitHub-native model (JOSS) has credibility and citations but **no IF after a decade** — its non-traditional review process is explicitly cited as the barrier to WoS/Scopus inclusion.
+
+## 2. Getting an impact factor as a new journal
+
+- **Path:** ISSN → DOAJ → Scopus and/or Web of Science ESCI → (optionally SCIE). **Since the 2023 JCR, all ESCI journals receive a Journal Impact Factor**, so ESCI is now the fastest IF route — no need to wait for SCIE promotion.
+- **WoS ESCI:** 24 quality criteria (ISSN, peer-review policy, ethics statement, timely publication, editorial-board affiliations, scope consistency, international authorship). Clarivate wants ~**2 years of regular publication** before submission; evaluation itself takes months to years; failed applications trigger embargo periods before re-submission.
+- **Scopus:** CSAB review, 6–12 months; ~**2 years of publication history** historically required, though the fixed 2-year rule was **dropped in August 2024** (CSAB still wants substantial published content). Real acceptance rate is **under 20%** of suggested titles.
+- **DOAJ:** open-access policy, ISSN, named editorial board with affiliations, documented peer review, article-level metadata, consistent publishing record — realistically achievable within year 1 and essentially free.
+- **Volume:** no formal minimum, but journals publishing <20–25 articles/year look fragile to evaluators; timeliness/regularity matters as much as volume.
+- **Realistic timeline: 3–5 years minimum** from launch to first IF (2 years of content + 1–2 years evaluation + JCR release cycle). Scientific Data's ~3 years is the best case, with Nature's machinery behind it.
+
+## 3. JOSS as the closest analog
+
+- **Mechanics:** submission = a repo + short (~1,000-word) Markdown paper. Review happens as **GitHub issues in `openjournals/joss-reviews`**, driven by **editorialbot** (open-source, reused by rOpenSci — directly relevant since openwashdata already uses R-package review conventions). Reviewers work through a public checklist; review is collaborative and iterative, not accept/reject.
+- **Costs:** famously ~**$3–6 per paper** (JOSS's own 2019 blog: ~$2.71/paper at 300 papers/yr): Crossref DOIs $1/article, Crossref membership ~$275/yr, Portico archiving ~$250/yr, hosting ~$228/yr. Fiscally sponsored by **NumFOCUS** under "Open Journals"; Sloan Foundation grant support.
+- **Scale/credibility:** 2,000th paper in May 2023; **400+ papers/yr**; ISSN, DOAJ-listed, Google Scholar-indexed, widely cited (papers like astropy accrue thousands of citations) — credibility came from community adoption, not indexing.
+- **The caveat that matters most:** JOSS has **not** been accepted by Scopus or WoS, so no impact factor. If IF is a hard requirement, pure JOSS-cloning is insufficient — you'd need JOSS-style mechanics plus a more conventional-looking editorial layer (formal editorial board, documented review policy, regular "issues"/volumes, ethics statements) to pass Clarivate's 24 criteria.
+- Sister journals: **JORS** (Ubiquity, predates JOSS, ~£350 APC) and **JOSE, Journal of Open Source Education** (2018, same Open Journals infrastructure).
+
+## 4. Is a WASH-niche data journal viable?
+
+- **Journal of Water, Sanitation and Hygiene for Development** (IWA Publishing, OA): IF ~1.4–1.8, Q3 — the sector flagship; publishes research/practice papers, **no data-paper article type**.
+- **npj Clean Water** (Springer Nature): IF ~11, APC ~$2,990 — high-end, technology-focused, no data papers.
+- **Water Research, Water Research X** (Elsevier/IWA): research only; data goes to Data in Brief via Elsevier's co-submission pipeline.
+- **Gap: real.** No WASH-specific data journal exists. WASH datasets currently route to generic venues (Data in Brief at $1,240, Scientific Data at $2,190) — both fee-bearing and neither tailored to practitioner data from low-resource settings, where APCs are a genuine barrier. A free venue is a differentiator, and it aligns with Gates Foundation economics (below).
+
+## 5. Lighter-weight credit mechanisms (the competition)
+
+- **DataCite DOIs** via Zenodo/Dryad/figshare/OSF: datasets are already first-class, citable outputs; Zenodo mints DataCite DOIs free. openwashdata packages can get DOIs today at zero cost.
+- **Gates Foundation 2025 OA policy** (highly relevant to WASH funding): mandatory preprints, immediate OA, **underlying data must be openly available**, and Gates **no longer pays APCs** (with a PLOS no-APC partnership 2025–27). This punishes APC journals and favors a diamond-OA venue — an argument *for* the model.
+- **CRediT taxonomy** (now ANSI/NISO standard) gives contributor-level credit including "Data curation."
+- **Data citation metrics** (DataCite Event Data, Make Data Count, Google Dataset Search) are growing but not yet career currency; hiring committees still read journal lines on CVs. That gap — datasets are citable but not "countable" for promotion — is precisely the niche a data journal fills. Evidence consistently shows papers with open data are cited more.
+
+## 6. Risks
+
+1. **No IF for years, possibly ever.** JOSS's decade-long exclusion shows unconventional review can permanently block WoS/Scopus. Scopus real acceptance <20%.
+2. **Starvation:** niche data journals run thin — Journal of Open Humanities Data manages ~76 articles/yr with a whole discipline behind it; Ubiquity's Open Health Data publishes a trickle. WASH is far smaller. A journal publishing <10 papers/yr will look dead to indexers and authors alike. (Counter-example of closure: Open Medicine folded in 2014 citing funding.)
+3. **Predatory-perception risk** for a new no-name journal: mitigate with named editorial board (ETH/Global South mix), ISSN, DOAJ listing early, transparent review, COPE-style policies.
+4. **Volunteer burnout:** JOSS survives on volunteer editors plus bot automation and Sloan/NumFOCUS backing; a WASH journal has a much smaller volunteer pool. Budget for automation (editorialbot is open source) and a paid managing-editor fraction.
+5. **Strategic risk:** by the time an IF arrives (2030+), data-citation metrics and funder mandates may have devalued it. A hedge: launch JOSS-style now (DOIs, DOAJ, Google Scholar), pursue Scopus/ESCI opportunistically, and treat IF as an option rather than the value proposition.
+
+Sources: [Scientific Data (Wikipedia)](https://en.wikipedia.org/wiki/Scientific_Data_(journal)), [Scientific Data metrics](https://journalsinsights.com/journals/scientific-data), [ESSD first IF announcement](https://www.earth-system-science-data.net/about/news_and_press/2016-06-17_first-impact-factor-for-essd.html), [ESSD metrics](https://www.journalmetrics.org/journal/earth-system-science-data), [Data in Brief insights](https://www.sciencedirect.com/journal/data-in-brief/about/insights), [Data in Brief metrics](https://researcher.life/journal/data-in-brief/12850), [JOSS about](https://joss.theoj.org/about), [FZ Jülich on JOSS indexing](https://www.fz-juelich.de/en/rse/the_latest/should-i-publish-in-the-journal-of-open-source-software), [JOSS cost models blog](https://blog.joss.theoj.org/2019/06/cost-models-for-running-an-online-open-journal), [JOSS 2000th paper](https://blog.joss.theoj.org/2023/05/JOSS-publishes-2000th-paper), [JOSS design & first-year review (PeerJ CS)](https://peerj.com/articles/cs-147/), [Open Journals joins NumFOCUS](https://numfocus.org/blog/open-journals-joins-numfocus-sponsored-projects), [editorialbot docs](https://joss.readthedocs.io/en/latest/editorial_bot.html), [Scholarly Kitchen on ESCI IFs](https://scholarlykitchen.sspnet.org/2022/07/26/the-end-of-journal-impact-factor-purgatory-and-numbers-to-the-thousandths/), [Clarivate journal evaluation criteria](https://clarivate.com/academia-government/scientific-and-academic-research/research-discovery-and-referencing/web-of-science/web-of-science-core-collection/editorial-selection-process/journal-evaluation-process-selection-criteria/), [Scopus content policy](https://www.elsevier.com/products/scopus/content/content-policy-and-selection), [Scopus policy changes blog](https://blog.scopus.com/scopus-content-policy-and-selection-changes/), [Scholastica on Scopus indexing](https://blog.scholasticahq.com/post/how-to-get-journals-indexed-scopus/), [JWSHD (IWA)](https://iwaponline.com/washdev), [JWSHD metrics](https://researcher.life/journal/journal-of-water-sanitation-and-hygiene-for-development/318), [npj Clean Water metrics](https://www.journalmetrics.org/journal/npj-clean-water), [Biodiversity Data Journal IF](https://www.journalmetrics.org/journal/biodiversity-data-journal), [Geoscience Data Journal (Wiley)](https://www.wiley.com/en-us/journals/Geoscience+Data+Journal-p-20496060), [JOHD metrics](https://www.resurchify.com/impact/details/21101102022), [JORS about](https://openresearchsoftware.metajnl.com/about), [JOSE about](https://jose.theoj.org/about), [Gates 2025 OA policy](https://openaccess.gatesfoundation.org/open-access-policy/2025-open-access-policy/), [Scholarly Kitchen on Gates policy](https://scholarlykitchen.sspnet.org/2024/04/15/gates-2025-open-access-policy/), [Science on Gates preprint mandate](https://www.science.org/content/article/bold-bid-avoid-open-access-fees-gates-foundation-says-grantees-must-post-preprints), [Zenodo data citation guide](https://zenodo.org/records/5523291), [Open Medicine closure (Wikipedia)](https://en.wikipedia.org/wiki/Open_Medicine_(John_Willinsky_journal))

--- a/dev/journal-2026-07/research-discoverability.md
+++ b/dev/journal-2026-07/research-discoverability.md
@@ -1,0 +1,40 @@
+# Dataset Discoverability for openwashdata: Findings
+
+Research-agent report, 2026-07-26. Companion evidence to `journal-plan-critique-and-approach.md`.
+Question: Zenodo records are reportedly not indexed by Google Scholar — what is actually true, and what are the levers for FAIR, *findable* data publishing?
+
+## 1. Zenodo × Google Scholar — verified status
+
+**Zenodo confirms it is not indexed by Google Scholar for datasets, and explains why.** The official FAQ ([support.zenodo.org, "Is Zenodo indexed by Google Scholar?"](https://support.zenodo.org/help/en-gb/29-indexing/61-is-zenodo-indexed-by-google-scholar)) states: Scholar "only indexes text content (articles)," so non-article resource types are out of scope; and Scholar infers resource type from **URL patterns** (e.g. `/articles/` vs `/data/`), which Zenodo cannot provide because users can change a record's resource type after publishing and Zenodo won't break stable URLs. Zenodo says it has met with Google repeatedly without resolution. So the cause is **both** Scholar's article-only scope **and** Zenodo's inability to signal type via URL — not primarily missing Highwire tags.
+
+**Scholar's inclusion rules** ([Inclusion Guidelines for Webmasters](https://scholar.google.com/intl/en/scholar/inclusion.html)): pages must look like scholarly articles (title, authors, abstract, full text/PDF), one article per unique URL, with Highwire Press tags — minimum `citation_title`, `citation_author` (first author), `citation_publication_date`; PDFs linked via `citation_pdf_url`. A pkgdown data page fails this test regardless of markup — there is no article-like PDF. Scholar does contain *some* dataset records (Webometrics runs a ["Transparent Ranking" of data repositories by Google Scholar presence](https://repositories.webometrics.info/en/data), and a [2024 Scientometrics study](https://link.springer.com/article/10.1007/s11192-024-05073-5) compared dataset citation coverage across GS/WoS/Scopus/DataCite), but this is incidental, not a reliable channel. **Verified conclusion: no amount of metadata tuning gets a Zenodo dataset record into Scholar.**
+
+## 2. Google Dataset Search — the actual dataset channel
+
+- Works purely from **schema.org/Dataset markup (JSON-LD) or DCAT** on ordinary crawled web pages ([Google's Dataset structured-data docs](https://developers.google.com/search/docs/appearance/structured-data/dataset)). Required: `name`, `description`; recommended: `creator`, `license`, `sameAs` (DOI), `distribution`, `isAccessibleForFree`.
+- **Zenodo IS indexed by Dataset Search** — stated in Zenodo's own FAQ (Dataset Search reads Zenodo's embedded schema.org metadata). So openwashdata datasets are likely already there, and would appear twice-over if pkgdown pages also carried valid markup.
+- For pkgdown sites: embed Dataset JSON-LD in each package page's head (pkgdown supports custom head includes via templates), ensure a **sitemap** (pkgdown generates `sitemap.xml`), and register **openwashdata.org in Search Console**; pages typically appear "within a few days" of crawl.
+- Usage evidence is real but modest: grew from ~500K schema.org datasets in 2016 to ~30M+ ([Noy/Brickley, "Google Dataset Search by the Numbers"](https://arxiv.org/pdf/2006.06894); [HDSR paper](https://hdsr.mitpress.mit.edu/pub/psnc8zsr/release/2)); ~45M datasets/13K sources per [Wikipedia](https://en.wikipedia.org/wiki/Google_Dataset_Search). *Inference:* far less used than Scholar by academics, but it is the only Google surface purpose-built for datasets.
+
+## 3. DataCite ecosystem — what the Zenodo DOI buys
+
+Verified: a DataCite DOI feeds [**DataCite Commons**](https://commons.datacite.org/) (citations, views, downloads per record), the **OpenAIRE Research Graph** (Zenodo is an OpenAIRE product; all records flow to [OpenAIRE Explore](https://www.openaire.eu/zenodo-guide)), and **BASE** via Zenodo's OAI-PMH endpoint. Zenodo is covered by the **Web of Science Data Citation Index** (per [re3data record](https://www.re3data.org/repository/r3d100010468)) — subscription-only, but real. [Make Data Count](https://makedatacount.org/find-a-tool/) and the Wellcome-funded [**Data Citation Corpus**](https://support.datacite.org/docs/data-citation-corpus) aggregate data citations to DataCite DOIs. **Limitation (verified pattern):** citations accrue only when papers cite the DOI formally in reference lists *and* publishers deposit the link — coverage is thin, and none of this surfaces in Scholar profiles. Scopus does not systematically index datasets.
+
+## 4. The data-paper workaround — the established fix
+
+A short **data descriptor with a Crossref DOI** (Scientific Data, Earth System Science Data, Data in Brief) is an article: Scholar indexes it, it accrues citations to the author's profile, and its `relatedIdentifiers`/references link to the DataCite dataset DOI. This is the standard "Scholar visibility via paper, data credit via DOI" pattern. **Free interim path (verified):** preprints. [EarthArXiv explicitly documents](https://eartharxiv.github.io/google_scholar.html) that Scholar crawls it ~weekly; [OSF Preprints are fully Scholar-indexed](https://help.osf.io/article/230-preprint-faqs) after CDL/COS optimized metadata with Google. A data-descriptor preprint on OSF/EarthArXiv gets Scholar presence at zero cost, before or without journal submission.
+
+## 5. ETH channel
+
+The [ETH Research Collection](https://library.ethz.ch/en/researching-and-publishing/publishing-and-registering/publishing-research-data.html) is a combined publications + data repository with its own DOIs (10.3929/…) and is covered by the Data Citation Index. *Inference (strong):* as a standard institutional repository it is Scholar-indexed for **text items** — depositing a PDF data descriptor/report there is another Scholar route for an ETH-affiliated group; its dataset records face the same Scholar limits as Zenodo's.
+
+## 6. Ranked action checklist (impact ÷ effort)
+
+1. **Write short data descriptors and post as preprints (OSF/EarthArXiv-style), citing the Zenodo DOI** — the only free, reliable path into Google Scholar. Upgrade the best ones to Data in Brief / Scientific Data later. *(High impact, medium effort.)*
+2. **Embed schema.org/Dataset JSON-LD in every pkgdown package page** (name, description, creator with ORCID, license, `sameAs` = Zenodo DOI, distribution = CSV/RDA URLs); validate with Google's **Rich Results Test** and the **Schema Markup Validator**; verify openwashdata.org in **Search Console** with sitemap submitted. *(High impact, low effort — templatable across all packages.)*
+3. **DataCite metadata completeness on Zenodo**: full creators/ORCIDs, ContactPerson, funding, and `relatedIdentifiers` (`IsDescribedBy`/`IsSupplementTo`) linking dataset ↔ descriptor both ways — this drives DataCite Commons, OpenAIRE, and the Data Citation Corpus. *(Medium impact, low effort.)*
+4. **CITATION.cff in every repo** (via `cffr`) → GitHub "Cite this repository" box; note `.zenodo.json` overrides CFF for Zenodo deposits, so keep both consistent ([Zenodo docs](https://help.zenodo.org/docs/github/describe-software/), [rOpenSci cffr](https://ropensci.org/blog/2021/11/23/cffr/)). *(Medium impact, very low effort.)*
+5. **Croissant JSON-LD** (schema.org extension; [MLCommons](https://mlcommons.org/2024/03/croissant_metadata_announce/)) for AI/ML consumers — supported by Dataset Search, Hugging Face, Kaggle; NeurIPS now requires it. Worth adding once item 2 exists. *(Low-medium impact today, low incremental effort.)*
+6. **ETH Research Collection deposits** of descriptor PDFs; **Wikidata** entries only opportunistically. *(Low priority.)*
+
+**Bottom line:** Scholar invisibility is structural to Zenodo datasets, not fixable by openwashdata; the levers are (a) article-shaped descriptors/preprints for Scholar, (b) JSON-LD + Search Console for Dataset Search, (c) DataCite relatedIdentifiers for machine-readable paper↔data credit.

--- a/dev/journal-2026-07/research-openwashdata-ecosystem.md
+++ b/dev/journal-2026-07/research-openwashdata-ecosystem.md
@@ -1,0 +1,41 @@
+# openwashdata ecosystem — factual research report (July 2026)
+
+Research-agent report, 2026-07-26. Companion evidence to `journal-plan-critique-and-approach.md`.
+
+**Method note:** The research environment's egress proxy blocked direct fetches of openwashdata.org, CRAN, github.io and zenodo.org. Findings were assembled from web search, the public source repo of the website (`openwashdata/website` — the site is a Quarto site whose catalogue CSV is committed to the repo), the CRAN GitHub mirror (`cran/washr`), and the local washr checkout. Genuinely unverifiable items are flagged.
+
+## 1. openwashdata.org catalogue
+
+- The Data page is a searchable table driven by a Google Sheet (`googlesheets4::read_sheet`), snapshotted to `pages/gallery/data/data_data/tbl-01-openwashdata-datasets.csv` in the website repo. Current snapshot: **56 datasets — 50 "published", 6 "in-progress"**, publication dates 2023-07-11 through 2026-02-26 (so still actively publishing).
+- Columns per dataset: id, pkg_name, maintainer (GitHub username), source (ngo 24, academic 20, government 3, private 3, multi-lateral 2), difficulty, status, description, location, date_published, GitHub link, pkgdown website link, DOI, temporal_coverage, keywords. **The public table displays only** id, name, location, status, description, published date and website link — maintainer, source, DOI and keywords are in the data but not shown.
+- **DOIs: 40 of 50 published packages have a Zenodo DOI (10.5281/zenodo.*); 10 do not.** DOIs come from the manual Zenodo–GitHub release integration (per the "Data Publishing with washr" guide, chapter `creating_doi.qmd`): first release tagged 0.0.1, upload type switched to "Dataset", DOI badge added to README. ETH Research Collection deposit is described as applying "only to GHE workflow submissions".
+- Citation guidance exists per package: washr generates `CITATION.cff` and `inst/CITATION` (`update_citation()`), and READMEs carry DOI + CC BY 4.0 badges (verified on washmalawi). Default dataset license is **CC BY 4.0**.
+- **Contribution process:** no web form. "Donate data" (navbar) points to GitHub issues on `openwashdata/data`; the README there instructs: open an issue titled "[data] …", describe the data, do **not** upload files, then the team follows up. The Get Started page tells contributors to get an ORCID iD, a GitHub account, and join the Matrix chat. A 2024-05-17 blog post ("Data donation") walks contributors step-by-step.
+
+## 2. washr on CRAN
+
+- **CRAN version: 1.0.1, published 2024-11-07** (maintainer then: Colin Walder). Title: "Publication Toolkit for Water, Sanitation and Hygiene (WASH) Data"; GPL (>= 3); authors Zhong, Götschmann, Walder, Schöbitz; copyright Global Health Engineering, ETH Zurich; docs at openwashdata.github.io/washr.
+- The GitHub repo has since released **1.0.2** (patch: bug fixes to `update_citation()`, `update_description()`, `setup_readme()`; **maintainer changed to Lars Schöbitz**) — the CRAN mirror still shows 1.0.1 as of this research, so 1.0.2 does not appear to be on CRAN yet. Dev version 1.0.2.9000 (Date 2026-07-23).
+- What it does: scaffolds an R data package in a consistent structure — tidy data export (`setup_rawdata`), data dictionary (`setup_dictionary`), DESCRIPTION defaults incl. CC BY 4.0 (`update_description`), README (`setup_readme`), pkgdown website with openwashdata theming (`setup_website`), citation files (`update_citation(doi=)`). The full end-to-end process is documented in the Quarto book "Data Publishing with washr" (Global-Health-Engineering/ghedatapublishing).
+
+## 3. Broader offering
+
+- **Academy:** "data science for openwashdata" (ds4owd) — free 10-week course (9 × 2.5 h Zoom + ~3 h/week homework), certificate, requires participants to bring a dataset to share. Iteration 001 produced ~40 graduates; iteration 002 recently wrapped with 40+ graduates (course site ds4owd-002.github.io/website). Site lists "Graduates 2024" and "Graduates 2026" pages.
+- **Community:** chat is **Matrix** (ETH `staffchat.ethz.ch`, ~100 active members per the Phase 2 proposal), not Slack; monthly newsletter (~200 recipients); ~10 unique site visitors/day. There is a Code of Conduct page.
+- **Funding:** explicitly stated — footer: "This project was supported by the Open Research Data Program of the ETH Board." Phase 1 Explore project "Open WASH data by building Open Science Competencies and Community" ran Mar 2023–Aug 2024; a **Phase 2 Explore proposal** ("Open WASH data by establishing Data Stewards and increasing FAIRness", Schöbitz & Tilley, submitted 2024-02-29) proposes data stewards in Malawi/South Africa, a 12-module data-stewardship curriculum, increased FAIRness, and a governance structure/sounding board. Funding amounts not published.
+
+## 4. Gaps relevant to a journal layer
+
+- **No maintenance policy found** anywhere on the site, guide, or repos.
+- **Maintainers/contacts:** tracked internally (GitHub usernames in the sheet; 17 of 50 published packages maintained by one person, emmanuellmhango) but **not displayed** in the public catalogue; contact is a generic ghe@mavt.ethz.ch.
+- **No terms of use or contributor agreement found** — only the Code of Conduct and per-package CC BY 4.0 licenses.
+- **Versioning:** ad hoc — packages carry versions (e.g., washmalawi 1.0.1) and Zenodo versions DOIs per GitHub release, but there is no stated dataset-versioning policy.
+- **No peer review:** the intake is a GitHub issue plus team-assisted cleaning; nothing resembling editorial or scientific review is described publicly. (washr 1.0.1's CRAN "review" was CRAN's technical review only. The pkgreview-based data reviews, e.g. solidwastekampala#17, are internal and not described on the public site.)
+
+## 5. Relationship to academic publishing
+
+- **No data papers found** accompanying any package; publication endpoints are GitHub + pkgdown + Zenodo (+ ETH Research Collection for GHE-internal data). A 2023 webinar was titled "a data sharing workflow that may please the publishers", indicating publisher-facing ambitions, but no journal partnership is stated.
+- **No peer-reviewed paper about the project itself found**; the citable outputs are the ORD proposals (posted with citation metadata) and the datasets. The `washopenresearch` package (DOI 10.5281/zenodo.11185699) analyses open-data statements in WASH literature — the closest thing to meta-research output.
+- **Citations:** could not verify any citations to openwashdata packages; note Zenodo datasets are not indexed by Google Scholar (Zenodo FAQ), which itself is a discoverability gap. Google Scholar could not be queried directly from the research environment.
+
+Sources: [openwashdata.org](https://openwashdata.org/), [Data catalogue](https://openwashdata.org/pages/gallery/data/), [website source repo](https://github.com/openwashdata/website), [washr on CRAN](https://cran.r-project.org/web/packages/washr/index.html), [washr pkgdown](https://openwashdata.github.io/washr/), [ghedatapublishing guide](https://global-health-engineering.github.io/ghedatapublishing/), [Phase 2 proposal](https://openwashdata.org/pages/gallery/proposal-02/), [ORD portal project page](https://open-research-data-portal.ch/projects/open-wash-data-by-building-open-science-competencies-and-community/), [openwashdata/data](https://github.com/openwashdata/data), [GHE ETH page](https://ghe.ethz.ch/open-science/projects/openwashdata.html).

--- a/dev/journal-2026-07/research-submission-governance.md
+++ b/dev/journal-2026-07/research-submission-governance.md
@@ -1,0 +1,76 @@
+# Submission & Governance Models for Package/Data Repositories
+
+Research-agent report, 2026-07-26. Companion evidence to `journal-plan-critique-and-approach.md`.
+Informs a CRAN-like submission layer for openwashdata. All findings drawn from the primary policy documents cited at the end.
+
+## 1. The CRAN model
+
+CRAN's governance rests on the **CRAN Repository Policy** (a single living HTML/PDF document, revision-numbered). Key maintainer requirements:
+
+- **Single designated maintainer with a valid email.** Each package `DESCRIPTION` names one `Maintainer` with a working address. CRAN corresponds only with that person; **a bouncing email is grounds for archival.** Maintainers "give the right to use that package name to CRAN when they submit" — so CRAN can orphan and reassign a package.
+- **Response obligations.** When CRAN flags a policy or check problem, maintainers are given a firm deadline (typically 2 weeks). Failure to respond or fix results in archival: "Packages for which R CMD check gives an 'ERROR' ... will be archived ... unless the maintainer has set a firm deadline for an upcoming update (and keeps to it)."
+- **Archival, not deletion.** Packages "will not normally be removed ... however, they may be archived." Archived packages leave the active repository but remain in the historical archive. **Orphaned packages may not be strict dependencies** (Depends/Imports/LinkingTo) of other packages.
+- **License requirements.** Must be an accepted open-source license (standardized in R's license list), with any non-standard terms in a `LICENSE` file. Ownership/copyright must be declarable.
+- **Submission pipeline.** Two-stage: (a) **automated** — `R CMD check --as-cran` must pass with no ERRORs/WARNINGs; incoming checks run automatically on submission; (b) **human review** by the small CRAN team. A separate **Submission Checklist** governs resubmissions, and there are limits on update frequency (roughly one release per 1–2 months) to reduce reviewer load.
+- **Maintainer changes** require "the written agreement of the previous maintainer (unless the package has been formally orphaned)."
+
+**What makes it work:** hard automation gate (most defects caught before a human looks), a stable written policy, and permanent archival. **Known pain points** (documented by community analyses and *R Packages*): a **volunteer reviewer bottleneck** — a handful of people do CRAN review on top of day jobs and R core work; **maintainer burden** from strict, sometimes opaque, feedback and tight fix deadlines; and **package archival cascades** when an upstream dependency is archived. Each `NOTE` consumes scarce human oversight, so submissions with zero NOTEs pass faster.
+
+## 2. rOpenSci software peer review (closest template)
+
+rOpenSci's **Dev Guide** ("Packages: Development, Maintenance, and Peer Review") defines an editorial, journal-like model conducted **openly on GitHub issues**:
+
+- **Editorial model.** A submission opens an issue; an **Editor-in-Chief / handling editor** checks scope and assigns **two reviewers**. Review is public and conversational in the issue thread. Two software-review streams exist (data-lifecycle packages, and statistical software with its own **standards** in the separate *Statistical Software Peer Review* guide).
+- **Automation.** The **`ropensci-review-bot`** runs `pkgcheck` (built on `pkgstats`) on submission and posts a report into the issue — "the primary source of information used to inform initial editorial decisions." Authors can run `pkgcheck` locally first.
+- **Maintainer responsibilities** are explicit: keep the package working, respond to issues, follow the **Code of Conduct**, and maintain the package after acceptance (it moves into the rOpenSci GitHub org / suite).
+- **Package Curation Policy** (Dev Guide ch. 17): staff-maintained packages are continuously built; on a **biannual/annual** basis rOpenSci reviews packages "failing for over a month" and moves persistently failing, unmaintained ones to the **`ropensci-archive`** GitHub org. Prioritization is by downloads, reverse-dependencies, and strategic goals.
+- **JOSS partnership / fast-track.** rOpenSci-accepted packages that are in JOSS scope and add a short paper get a **fast-tracked JOSS review** at JOSS editors' discretion (JOSS normally requires two reviewers; previously rOpenSci/pyOpenSci-reviewed packages are exempted from re-review).
+
+This is the strongest single template for openwashdata: open review, bot-driven checks, explicit maintainer contract, and an archival lifecycle.
+
+## 3. Data-repository certification & stewardship norms
+
+- **CoreTrustSeal** (Requirements 2023–2025): **16 requirements** covering organizational infrastructure, digital-object management, and technology, built on the **FAIR** principles. Directly relevant clauses: **R09 Preservation Plan**, **R10 Quality Assurance**, **R11 Workflows**, plus **continuity-of-access** provisions (a repository must plan for what happens if it ceases operations). Certification requires documented, evidenced responses per requirement.
+- **DataCite Metadata Schema 4.5** — mandatory properties include **Creator** (`creatorName`); **Contributor** is optional but *if used* `contributorType` and `contributorName` are **mandatory**. The **`ContactPerson`** contributor type = "Person with knowledge of how to access, troubleshoot, or otherwise field issues related to the resource" — the schema-native way to encode a **dataset maintainer/contact**. This maps cleanly to a required-maintainer field. Contacts can be organizational.
+- **FAIR operationalized** — Findable (persistent ID + rich metadata), Accessible, Interoperable (standard vocabularies), Reusable (clear license + provenance). Certification schemes translate these into checkable repository practices.
+- **Dryad** — a **staffed curation model**: human curators check *every* dataset for file readability, metadata completeness, license, README quality, and sensitive/identifiable data before the **DOI is registered**; curators contact submitters by email for fixes. Curation is a gate to publication.
+- **Zenodo (contrast)** — **no scientific curation**: "Zenodo does not assess the scientific correctness or quality of submissions"; depositors bear responsibility for meeting research standards. Only **automated + manual spam moderation** and optional **community-level review policies** exist. This is the low-friction, low-assurance end of the spectrum.
+
+## 4. Terms-of-reference / responsibility documents
+
+- **CRAN Policy** — the canonical single-document ToR (see §1).
+- **rOpenSci** — a layered set worth emulating: **Code of Conduct**, a **maintainer guide**, and the **Package Curation Policy** (archival + succession) together form the responsibility contract.
+- **JOSS** — public **author** and **reviewer** guidelines plus a **review checklist**: OSI-approved `LICENSE` file must physically exist; **substantial scholarly effort** (≥ ~3 person-months); functionality, tests, documentation, and community-contribution guidelines all checked.
+- **Bioconductor** — most relevant on maintainer accountability: maintainers must keep the `DESCRIPTION` email **accurate and reachable** (bounces jeopardize the package); `BiocCheck` enforces guidelines; a **one-year End-of-Life / deprecation process** applies to packages that fail build/check with an unresponsive maintainer, after automated and private-email outreach. Deprecated packages get a load-time warning and a strikethrough on the build report.
+- **DOAJ / COPE** — if a journal layer is added, these supply editorial-integrity and publication-ethics norms (transparency, misconduct handling); note as a future add-on.
+
+## 5. Data-specific submission review criteria in practice
+
+- **ESSD (Earth System Science Data)** publishes a **formal review-criteria checklist**. Reviewers assess: is the dataset **significant** (unique, useful, **complete** — and not artificially split to inflate publications); is it **usable** in its current format/size with **appropriate formal metadata**; and does the accompanying text contain all information needed to **evaluate every claim** about the data. Data must sit in a suitable, quality-assured repository (ESSD's separate **Repository Criteria**).
+- **Scientific Data** applies analogous technical-soundness and metadata-completeness checks (its "Data Descriptor" model).
+- **Data Curation Network — CURATE(D) checklist:** **C**heck files/documentation, **U**nderstand (run/QA the data), **R**equest missing info/changes, **A**ugment metadata for findability, **T**ransform formats for reuse, **E**valuate for FAIRness, **D**ocument the curation steps. This is a ready-made, standardized reviewer checklist for datasets.
+
+## 6. Sustainability & succession
+
+The recurring risk — a maintainer leaving academia, retiring, or dying — is addressed differently across communities:
+
+- **CRAN:** archival + name-reassignment; orphaned packages barred as hard dependencies.
+- **Bioconductor:** explicit one-year EOL/deprecation for unresponsive maintainers with staged email outreach.
+- **rOpenSci:** the most proactive — a documented **"Changing package maintainers"** chapter, **annual maintainer surveys** to surface people ready to step down, **"Call for Contributors"** newsletter recruitment for orphaned packages, encouragement of **co-maintainership**, and `ropensci-archive` as a dignified end state. It explicitly names the human cause: "people change jobs, move locations, retire, and unfortunately die."
+- **Institutional vs personal maintainership:** DataCite's `ContactPerson` can be an **organizational** point of contact, and CoreTrustSeal's continuity-of-access requirement pushes repositories toward institutional rather than purely personal stewardship — the most robust hedge against individual departure.
+
+**Design implications for openwashdata:** adopt rOpenSci's open-GitHub-issue + review-bot model as the spine; require a named maintainer with a reachable email as a DataCite `ContactPerson` (allowing an institutional fallback); write a single ToR document combining CRAN-style obligations, a Code of Conduct, and an explicit deprecation/succession policy (Bioconductor's one-year EOL is a concrete template); gate submissions with automated checks (a washr equivalent of `pkgcheck`) plus a human curation step using a CURATE(D)-derived dataset checklist; and archive rather than delete.
+
+## Sources
+
+- [CRAN Repository Policy](https://cran.r-project.org/web/packages/policies.html) · [Checklist for CRAN submissions](https://cran.r-project.org/web/packages/submission_checklist.html) · [Reasons packages are archived (analysis)](https://llrs.dev/post/2021/12/07/reasons-cran-archivals/) · [CRAN review pain points (analysis)](https://llrs.dev/post/2021/01/31/cran-review/) · [R Packages (2e), Releasing to CRAN](https://r-pkgs.org/release.html)
+- [rOpenSci Dev Guide — Software Peer Review policies](https://devguide.ropensci.org/softwarereview_policies.html) · [Package Curation Policy](https://devguide.ropensci.org/maintenance_curation.html) · [Changing package maintainers](https://devguide.ropensci.org/maintenance_changing_maintainers.html) · [rOpenSci Statistical Software Peer Review](https://stats-devguide.ropensci.org/) · [Editorial Challenges blog](https://ropensci.org/blog/2022/04/19/software-review-editorial-challenges/)
+- [CoreTrustSeal Requirements 2023–2025](https://zenodo.org/records/7051237)
+- [DataCite Metadata Schema 4.5 — Contributor](https://datacite-metadata-schema.readthedocs.io/en/4.5/properties/contributor/) · [contributorType (ContactPerson)](https://datacite-metadata-schema.readthedocs.io/en/4.5/appendices/appendix-1/contributorType/)
+- [Dryad — Dataset curation](https://datadryad.org/help/guides/curation) · [Zenodo — content suitability / curation FAQ](https://support.zenodo.org/help/en-gb/2-content/141-what-content-is-not-suitable-for-zenodo)
+- [JOSS Review criteria](https://joss.readthedocs.io/en/latest/review_criteria.html) · [JOSS Review checklist](https://joss.readthedocs.io/en/latest/review_checklist.html)
+- [Bioconductor Package End of Life / Deprecation Policy](https://contributions.bioconductor.org/package-end-of-life-policy.html) · [Package guidelines](https://master.bioconductor.org/developers/package-guidelines/)
+- [ESSD Review criteria](https://www.earth-system-science-data.net/peer_review/review_criteria.html) · [ESSD Repository criteria](https://www.earth-system-science-data.net/policies/repository_criteria.html)
+- [Data Curation Network — CURATE(D) steps](https://datacuration.network/outputs/workflows/) · [CURATED checklist v.2 (U. Minnesota)](https://conservancy.umn.edu/items/2449305b-4cdc-4fbc-9902-2795b020c939)
+
+Note: several primary sites (`cran.r-project.org`, `datadryad.org`, `openwashdata.org`) returned HTTP 403 to direct fetch through the research environment's proxy; findings for those were assembled from search-indexed content and mirror pages, which reproduced the relevant clauses verbatim.


### PR DESCRIPTION
Adds `dev/journal-2026-07/` with the strategy documents behind issues #91–#96:

- `journal-plan-critique-and-approach.md` — critique of the openwashdata journal plan and the three-phase structured approach (submission policy → editorial layer → journal wrapper, each gated)
- `research-data-journals.md` — data-journal landscape: impact-factor routes (ESCI since 2023), JOSS model and its indexing failure, fees, viability, risks
- `research-submission-governance.md` — submission/governance models: CRAN, rOpenSci, Bioconductor EOL, DataCite ContactPerson, CoreTrustSeal, CURATE(D), ESSD review criteria
- `research-openwashdata-ecosystem.md` — current public state of the catalogue (56 datasets, DOI coverage, maintainer visibility, policy gaps)
- `research-discoverability.md` — Zenodo × Google Scholar (structural invisibility), Google Dataset Search, DataCite ecosystem, ranked action checklist

Docs only, no code changes. Merging to main so the issue links don't rot when the branch is cleaned up (coherence finding D5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXQHGAgdXR5w35RomeDWeK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXQHGAgdXR5w35RomeDWeK)_